### PR TITLE
feat: remove custom commitlint configuration

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,9 +1,0 @@
-export default {
-  extends: ['@commitlint/config-conventional'],
-  /*
-   * Any rules defined here will override rules from @commitlint/config-conventional
-   */
-  rules: {
-    'body-max-line-length': [2, 'always', 200],
-  },
-};


### PR DESCRIPTION
This commit removes the custom commitlint configuration file. 
The removal simplifies the setup by relying on the default rules 
provided by the conventional configuration, ensuring consistency 
and alignment with common practices.